### PR TITLE
Apply Ambient Occlusion only to IBL (diffuse part)

### DIFF
--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -537,6 +537,13 @@ void main()
     #endif
 #endif
 
+    float ao = 1.0;
+    // Apply optional PBR terms for additional (optional) shading
+#ifdef HAS_OCCLUSION_MAP
+    ao = texture(u_OcclusionSampler,  getOcclusionUV()).r;
+    f_diffuse = mix(f_diffuse, f_diffuse * ao, u_OcclusionStrength);
+#endif
+
 #ifdef USE_PUNCTUAL
     for (int i = 0; i < LIGHT_COUNT; ++i)
     {
@@ -644,13 +651,6 @@ void main()
     #endif
 
     color = (f_emissive + diffuse + f_specular + f_subsurface + (1.0 - reflectance) * f_sheen) * (1.0 - clearcoatFactor * clearcoatFresnel) + f_clearcoat * clearcoatFactor;
-
-    float ao = 1.0;
-    // Apply optional PBR terms for additional (optional) shading
-#ifdef HAS_OCCLUSION_MAP
-    ao = texture(u_OcclusionSampler,  getOcclusionUV()).r;
-    color = mix(color, color * ao, u_OcclusionStrength);
-#endif
 
 #ifndef DEBUG_OUTPUT // no debug
 


### PR DESCRIPTION
Ambient Occlusion should NOT be applied to direct lighting and the specular component of IBL

see: 
https://ux3d.myjetbrains.com/youtrack/issue/GSVN-32
https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/138