### PR TITLE
Override source if basisu is present

### DIFF
--- a/src/texture.js
+++ b/src/texture.js
@@ -26,6 +26,17 @@ class gltfTexture extends GltfObject
         initGlForMembers(this, gltf);
     }
 
+    fromJson(jsonTexture)
+    {
+        super.fromJson(jsonTexture);
+        if (jsonTexture.extensions !== undefined &&
+            jsonTexture.extensions.KHR_texture_basisu !== undefined &&
+            jsonTexture.extensions.KHR_texture_basisu.source !== undefined)
+        {
+            this.source = jsonTexture.extensions.KHR_texture_basisu.source;
+        }
+    }
+
     destroy()
     {
         if (this.glTexture !== undefined)


### PR DESCRIPTION
We can not load ktx images currently. Therefore, the rendering does not work for ktx files