### PR TITLE
Revert "Use x for one-channel textures to avoid misunderstandings"

### DIFF
--- a/source/Renderer/shaders/pbr.frag
+++ b/source/Renderer/shaders/pbr.frag
@@ -266,7 +266,7 @@ MaterialInfo getVolumeInfo(MaterialInfo info)
 
     #ifdef HAS_THICKNESS_MAP
         vec4 thicknessSample = texture(u_ThicknessSampler, getThicknessUV());
-        info.thickness *= thicknessSample.x;
+        info.thickness *= thicknessSample.g;
     #endif
 
     return info;


### PR DESCRIPTION
Reverts ux3d/glTF-Sample-Viewer#158

according to the spec the thickness value should be sampled from the g channel

https://github.com/DassaultSystemes-Technology/glTF/tree/KHR_materials_volume/extensions/2.0/Khronos/KHR_materials_volume